### PR TITLE
Add confirmation pop-ups for edit/delete

### DIFF
--- a/DangQuangTien_RazorPages/Pages/Account/Delete.cshtml
+++ b/DangQuangTien_RazorPages/Pages/Account/Delete.cshtml
@@ -11,7 +11,7 @@
 <div class="mb-3">
     <strong>Role:</strong> @(Model.Account?.AccountRole == 1 ? "Staff" : "Lecturer")
 </div>
-<form method="post">
+<form method="post" data-confirm="Are you sure you want to delete this account?">
     <input type="hidden" asp-for="Account!.AccountId" />
     <button type="submit" class="btn btn-danger">Delete</button>
     <a asp-page="Index" class="btn btn-secondary">Cancel</a>

--- a/DangQuangTien_RazorPages/Pages/Account/Index.cshtml
+++ b/DangQuangTien_RazorPages/Pages/Account/Index.cshtml
@@ -30,7 +30,7 @@
                 <td>
                     @if (acc.AccountId != 0)
                     {
-                        <a asp-page="Delete" asp-route-id="@acc.AccountId" class="btn btn-sm btn-danger">Delete</a>
+                        <a asp-page="Delete" asp-route-id="@acc.AccountId" class="btn btn-sm btn-danger" data-confirm="Are you sure you want to delete this account?">Delete</a>
                     }
                 </td>
             </tr>

--- a/DangQuangTien_RazorPages/Pages/Category/Delete.cshtml
+++ b/DangQuangTien_RazorPages/Pages/Category/Delete.cshtml
@@ -14,7 +14,7 @@
     </dl>
 </div>
 
-<form method="post">
+<form method="post" data-confirm="Are you sure you want to delete this category?">
     <button type="submit" class="btn btn-danger">Delete</button>
     <a asp-page="Index" class="btn btn-secondary">Cancel</a>
 </form>

--- a/DangQuangTien_RazorPages/Pages/Category/Edit.cshtml
+++ b/DangQuangTien_RazorPages/Pages/Category/Edit.cshtml
@@ -4,7 +4,7 @@
 
 <h2>Edit Category</h2>
 
-<form method="post">
+<form method="post" data-confirm="Save changes to this category?">
     <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
 
     <input type="hidden" asp-for="Category.CategoryId" />

--- a/DangQuangTien_RazorPages/Pages/Category/Index.cshtml
+++ b/DangQuangTien_RazorPages/Pages/Category/Index.cshtml
@@ -40,7 +40,7 @@
                     @if (Model.UserRole == 1)
                     {
                         <a asp-page="Edit" asp-route-id="@cat.CategoryId" class="btn btn-sm btn-warning">Edit</a>
-                        <a asp-page="Delete" asp-route-id="@cat.CategoryId" class="btn btn-sm btn-danger">Delete</a>
+                        <a asp-page="Delete" asp-route-id="@cat.CategoryId" class="btn btn-sm btn-danger" data-confirm="Are you sure you want to delete this category?">Delete</a>
                     }
                 </td>
             </tr>

--- a/DangQuangTien_RazorPages/Pages/News/Delete.cshtml
+++ b/DangQuangTien_RazorPages/Pages/News/Delete.cshtml
@@ -21,7 +21,7 @@
     <dd class="col-sm-9">@Model.Article?.CreatedDate?.ToLocalTime().ToString("g")</dd>
 </dl>
 
-<form method="post">
+<form method="post" data-confirm="Are you sure you want to delete this article?">
     <input type="hidden" asp-for="Article.NewsArticleId" />
     <button type="submit" class="btn btn-danger">Delete</button>
     <a asp-page="Index" class="btn btn-secondary">Cancel</a>

--- a/DangQuangTien_RazorPages/Pages/News/Edit.cshtml
+++ b/DangQuangTien_RazorPages/Pages/News/Edit.cshtml
@@ -6,7 +6,7 @@
 
 <h1>Edit Article</h1>
 
-<form method="post">
+<form method="post" data-confirm="Save changes to this article?">
     <input type="hidden" asp-for="Article.NewsArticleId" />
 
     <div class="mb-3">

--- a/DangQuangTien_RazorPages/Pages/News/Index.cshtml
+++ b/DangQuangTien_RazorPages/Pages/News/Index.cshtml
@@ -58,7 +58,7 @@
                 {
                     <td>
                         <a asp-page="Edit" asp-route-id="@article.NewsArticleId" class="btn btn-warning btn-sm">Edit</a>
-                        <a asp-page="Delete" asp-route-id="@article.NewsArticleId" class="btn btn-danger btn-sm">Delete</a>
+                        <a asp-page="Delete" asp-route-id="@article.NewsArticleId" class="btn btn-danger btn-sm" data-confirm="Are you sure you want to delete this article?">Delete</a>
                     </td>
                 }
             </tr>

--- a/DangQuangTien_RazorPages/wwwroot/js/site.js
+++ b/DangQuangTien_RazorPages/wwwroot/js/site.js
@@ -2,3 +2,23 @@
 // for details on configuring this project to bundle and minify static web assets.
 
 // Write your JavaScript code.
+
+// Generic confirmation handler for links and forms
+document.addEventListener('DOMContentLoaded', function () {
+    document.querySelectorAll('[data-confirm]').forEach(function (el) {
+        var msg = el.getAttribute('data-confirm');
+        if (el.tagName === 'FORM') {
+            el.addEventListener('submit', function (e) {
+                if (!confirm(msg)) {
+                    e.preventDefault();
+                }
+            });
+        } else {
+            el.addEventListener('click', function (e) {
+                if (!confirm(msg)) {
+                    e.preventDefault();
+                }
+            });
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- add a generic data-confirm handler script
- use data-confirm on delete links and forms
- confirm edits before submitting forms

## Testing
- `dotnet build DangQuangTien_Se171443_A02.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867b6c78c50832d989b821c3cc15908