### PR TITLE
Add admin account editing page

### DIFF
--- a/DangQuangTien_RazorPages/Pages/Account/Edit.cshtml
+++ b/DangQuangTien_RazorPages/Pages/Account/Edit.cshtml
@@ -1,0 +1,43 @@
+@page "{id:int}"
+@model DangQuangTien_RazorPages.Pages.Account.EditModel
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+
+<h2>Edit Account</h2>
+
+<form method="post" asp-antiforgery="true" data-confirm="Save changes to this account?">
+    <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
+    <input type="hidden" asp-for="Account.AccountId" />
+
+    <div class="mb-3">
+        <label asp-for="Account.AccountName" class="form-label"></label>
+        <input asp-for="Account.AccountName" class="form-control" />
+        <span asp-validation-for="Account.AccountName" class="text-danger"></span>
+    </div>
+
+    <div class="mb-3">
+        <label asp-for="Account.AccountEmail" class="form-label"></label>
+        <input asp-for="Account.AccountEmail" class="form-control" />
+        <span asp-validation-for="Account.AccountEmail" class="text-danger"></span>
+    </div>
+
+    <div class="mb-3">
+        <label asp-for="Account.AccountPassword" class="form-label"></label>
+        <input asp-for="Account.AccountPassword" type="password" class="form-control" />
+        <span asp-validation-for="Account.AccountPassword" class="text-danger"></span>
+    </div>
+
+    <div class="mb-3">
+        <label asp-for="Account.AccountRole" class="form-label"></label>
+        <select asp-for="Account.AccountRole" class="form-select">
+            <option value="1">Staff</option>
+            <option value="2">Lecturer</option>
+        </select>
+    </div>
+
+    <button type="submit" class="btn btn-primary">Save</button>
+    <a asp-page="Index" class="btn btn-secondary">Cancel</a>
+</form>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/DangQuangTien_RazorPages/Pages/Account/Edit.cshtml.cs
+++ b/DangQuangTien_RazorPages/Pages/Account/Edit.cshtml.cs
@@ -1,0 +1,45 @@
+using System.Threading.Tasks;
+using DAL.Entities;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Http;
+using ServiceLayer.Interfaces;
+
+namespace DangQuangTien_RazorPages.Pages.Account
+{
+    public class EditModel : PageModel
+    {
+        private readonly IAccountService _svc;
+        public EditModel(IAccountService svc) => _svc = svc;
+
+        [BindProperty]
+        public SystemAccount Account { get; set; } = new();
+
+        public async Task<IActionResult> OnGetAsync(short id)
+        {
+            var role = HttpContext.Session.GetInt32("AccountRole");
+            if (role != 0)
+                return RedirectToPage("/Account/AccessDenied");
+
+            var acc = await _svc.GetByIdAsync(id);
+            if (acc == null)
+                return RedirectToPage("Index");
+
+            Account = acc;
+            return Page();
+        }
+
+        public async Task<IActionResult> OnPostAsync()
+        {
+            var role = HttpContext.Session.GetInt32("AccountRole");
+            if (role != 0)
+                return RedirectToPage("/Account/AccessDenied");
+
+            if (!ModelState.IsValid)
+                return Page();
+
+            await _svc.UpdateAsync(Account);
+            return RedirectToPage("Index");
+        }
+    }
+}

--- a/DangQuangTien_RazorPages/Pages/Account/Index.cshtml
+++ b/DangQuangTien_RazorPages/Pages/Account/Index.cshtml
@@ -30,6 +30,7 @@
                 <td>
                     @if (acc.AccountId != 0)
                     {
+                        <a asp-page="Edit" asp-route-id="@acc.AccountId" class="btn btn-sm btn-warning me-1">Edit</a>
                         <a asp-page="Delete" asp-route-id="@acc.AccountId" class="btn btn-sm btn-danger" data-confirm="Are you sure you want to delete this account?">Delete</a>
                     }
                 </td>


### PR DESCRIPTION
## Summary
- create Account Edit page
- implement admin-only edit logic
- update account listing with Edit button

## Testing
- `dotnet build DangQuangTien_Se171443_A02.sln`

------
https://chatgpt.com/codex/tasks/task_e_6867c93340d4832d82a7d16e772b21ac