### PR TITLE
Allow admin updates to account email and role

### DIFF
--- a/DAL/Repositories/ISystemAccountRepository.cs
+++ b/DAL/Repositories/ISystemAccountRepository.cs
@@ -7,6 +7,13 @@ namespace DAL.Repositories
     {
         Task<SystemAccount?> GetByEmailAndPasswordAsync(string email, string password);
         Task<SystemAccount?> GetByIdAsync(short id);
+        /// <summary>
+        /// Update an existing account. Name and password are always updated.
+        /// When the supplied <see cref="SystemAccount"/> contains different
+        /// <c>AccountEmail</c> or <c>AccountRole</c> values, these changes are
+        /// applied as well. Normal profile edits reuse the existing values, so
+        /// only administrators can modify email and role.
+        /// </summary>
         Task UpdateAsync(SystemAccount account);
         Task AddAsync(SystemAccount account);
         Task DeleteAsync(short id);

--- a/DAL/Repositories/SystemAccountRepository.cs
+++ b/DAL/Repositories/SystemAccountRepository.cs
@@ -32,10 +32,18 @@ namespace DAL.Repositories
             if (existing == null)
                 throw new DbUpdateConcurrencyException("Account no longer exists.");
 
-            // Update only fields allowed to change
+            // Fields always editable by the owner
             existing.AccountName = updated.AccountName;
             existing.AccountPassword = updated.AccountPassword;
-            // Avoid changing Email or Role unless admin context
+
+            // Email and role can only be modified by an admin. The calling
+            // code for admin edits supplies the new values whereas profile
+            // updates reuse the existing entity so these remain unchanged.
+            if (existing.AccountEmail != updated.AccountEmail)
+                existing.AccountEmail = updated.AccountEmail;
+
+            if (existing.AccountRole != updated.AccountRole)
+                existing.AccountRole = updated.AccountRole;
 
             await _ctx.SaveChangesAsync();
         }


### PR DESCRIPTION
## Summary
- permit changing AccountEmail and AccountRole inside `UpdateAsync`
- document the behavior in repository interface

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867cb00ca74832db39f447992b320e2