### PR TITLE
Enhance account search and popup editing

### DIFF
--- a/DangQuangTien_RazorPages/Pages/Account/Index.cshtml
+++ b/DangQuangTien_RazorPages/Pages/Account/Index.cshtml
@@ -5,7 +5,16 @@
 }
 
 <h1>Account Management</h1>
-<a asp-page="Create" class="btn btn-primary mb-3" data-popup="create">New Account</a>
+
+<form method="get" class="row mb-3">
+    <div class="col-auto">
+        <input asp-for="SearchTerm" class="form-control" placeholder="Search..." />
+    </div>
+    <div class="col-auto">
+        <button type="submit" class="btn btn-primary">Search</button>
+        <a asp-page="Create" class="btn btn-success" data-popup="create">New Account</a>
+    </div>
+</form>
 
 <table class="table table-bordered table-hover table-striped mt-3">
     <thead class="table-light">
@@ -30,7 +39,7 @@
                 <td>
                     @if (acc.AccountId != 0)
                     {
-                        <a asp-page="Edit" asp-route-id="@acc.AccountId" class="btn btn-sm btn-warning me-1">Edit</a>
+                        <a asp-page="Edit" asp-route-id="@acc.AccountId" class="btn btn-sm btn-warning me-1" data-popup="edit">Edit</a>
                         <a asp-page="Delete" asp-route-id="@acc.AccountId" class="btn btn-sm btn-danger" data-confirm="Are you sure you want to delete this account?">Delete</a>
                     }
                 </td>

--- a/DangQuangTien_RazorPages/Pages/Account/Index.cshtml.cs
+++ b/DangQuangTien_RazorPages/Pages/Account/Index.cshtml.cs
@@ -14,6 +14,9 @@ namespace DangQuangTien_RazorPages.Pages.Account
             _accountService = accountService;
         }
 
+        [BindProperty(SupportsGet = true)]
+        public string? SearchTerm { get; set; }
+
         public List<SystemAccount> Accounts { get; set; }
 
         public IActionResult OnGet()
@@ -27,7 +30,18 @@ namespace DangQuangTien_RazorPages.Pages.Account
             if (role != 0)
                 return RedirectToPage("/Account/AccessDenied");
 
-            Accounts = _accountService.GetAllAccounts().ToList();
+            var all = _accountService.GetAllAccounts();
+
+            if (!string.IsNullOrWhiteSpace(SearchTerm))
+            {
+                var term = SearchTerm.Trim().ToLower();
+                all = all.Where(a =>
+                    (!string.IsNullOrEmpty(a.AccountName) && a.AccountName.ToLower().Contains(term)) ||
+                    (!string.IsNullOrEmpty(a.AccountEmail) && a.AccountEmail.ToLower().Contains(term))
+                );
+            }
+
+            Accounts = all.ToList();
             return Page();
         }
     }

--- a/DangQuangTien_RazorPages/Pages/Category/Index.cshtml
+++ b/DangQuangTien_RazorPages/Pages/Category/Index.cshtml
@@ -39,7 +39,7 @@
                 <td>
                     @if (Model.UserRole == 1)
                     {
-                        <a asp-page="Edit" asp-route-id="@cat.CategoryId" class="btn btn-sm btn-warning">Edit</a>
+                        <a asp-page="Edit" asp-route-id="@cat.CategoryId" class="btn btn-sm btn-warning" data-popup="edit">Edit</a>
                         <a asp-page="Delete" asp-route-id="@cat.CategoryId" class="btn btn-sm btn-danger" data-confirm="Are you sure you want to delete this category?">Delete</a>
                     }
                 </td>

--- a/DangQuangTien_RazorPages/Pages/News/Index.cshtml
+++ b/DangQuangTien_RazorPages/Pages/News/Index.cshtml
@@ -57,7 +57,7 @@
                 @if (Model.CanEdit)
                 {
                     <td>
-                        <a asp-page="Edit" asp-route-id="@article.NewsArticleId" class="btn btn-warning btn-sm">Edit</a>
+                        <a asp-page="Edit" asp-route-id="@article.NewsArticleId" class="btn btn-warning btn-sm" data-popup="edit">Edit</a>
                         <a asp-page="Delete" asp-route-id="@article.NewsArticleId" class="btn btn-danger btn-sm" data-confirm="Are you sure you want to delete this article?">Delete</a>
                     </td>
                 }

--- a/DangQuangTien_RazorPages/Pages/Shared/_EditPopupPartial.cshtml
+++ b/DangQuangTien_RazorPages/Pages/Shared/_EditPopupPartial.cshtml
@@ -1,0 +1,7 @@
+<div class="modal fade" id="editModal" tabindex="-1" aria-labelledby="editModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <!-- Edit form is loaded here -->
+        </div>
+    </div>
+</div>

--- a/DangQuangTien_RazorPages/Pages/Shared/_Layout.cshtml
+++ b/DangQuangTien_RazorPages/Pages/Shared/_Layout.cshtml
@@ -93,8 +93,10 @@
     <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
     <script src="~/js/site.js" asp-append-version="true"></script>
     <script src="~/js/createPopup.js" asp-append-version="true"></script>
+    <script src="~/js/editPopup.js" asp-append-version="true"></script>
 
     @await Html.PartialAsync("_CreatePopupPartial")
+    @await Html.PartialAsync("_EditPopupPartial")
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/microsoft-signalr/8.0.0/signalr.min.js"></script>
     <script>

--- a/DangQuangTien_RazorPages/wwwroot/js/editPopup.js
+++ b/DangQuangTien_RazorPages/wwwroot/js/editPopup.js
@@ -1,0 +1,14 @@
+// Script to show edit pages in an iframe inside a Bootstrap modal
+
+document.addEventListener('DOMContentLoaded', function () {
+    document.querySelectorAll('a[data-popup="edit"]').forEach(function (link) {
+        link.addEventListener('click', function (e) {
+            e.preventDefault();
+            var url = link.getAttribute('href');
+            var modalEl = document.getElementById('editModal');
+            modalEl.querySelector('.modal-content').innerHTML = '<iframe src="' + url + '" class="w-100" style="height:80vh;border:0;"></iframe>';
+            var modal = new bootstrap.Modal(modalEl);
+            modal.show();
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- add search box for account management
- filter accounts by search term
- enable popup editing via new partial and script
- load edit modal in layout and apply to account, category and news pages

## Testing
- `dotnet build DangQuangTien_Se171443_A02.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867cbef4274832db3d8f8c24ffc992f