### PR TITLE
Use service layer in Razor Pages

### DIFF
--- a/DangQuangTien_RazorPages/Pages/News/Index.cshtml.cs
+++ b/DangQuangTien_RazorPages/Pages/News/Index.cshtml.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using DAL.Entities;
-using DAL.Repositories;
+using ServiceLayer.Interfaces;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -13,13 +13,13 @@ namespace DangQuangTien_RazorPages.Pages.News
 {
     public class IndexModel : PageModel
     {
-        private readonly INewsArticleRepository newsRepo;
-        private readonly ICategoryRepository categoryRepo;
+        private readonly INewsService _news;
+        private readonly ICategoryService _cats;
         private readonly NotificationService _notificationService;
-        public IndexModel(INewsArticleRepository newsRepo, ICategoryRepository categoryRepo, NotificationService notificationService)
+        public IndexModel(INewsService news, ICategoryService cats, NotificationService notificationService)
         {
-            this.newsRepo = newsRepo;
-            this.categoryRepo = categoryRepo;
+            _news = news;
+            _cats = cats;
             _notificationService = notificationService;
         }
 
@@ -52,7 +52,7 @@ namespace DangQuangTien_RazorPages.Pages.News
                 CanEdit = false;
             }
 
-            Categories = (await categoryRepo.GetAllAsync()).ToList();
+            Categories = (await _cats.GetAllAsync()).ToList();
 
             await LoadArticles();
 
@@ -83,14 +83,11 @@ namespace DangQuangTien_RazorPages.Pages.News
 
         private async Task LoadArticles()
         {
-            var articles = (await newsRepo.GetAllAsync(SearchTerm)).AsQueryable();
-            
+            var articles = (await _news.GetAllAsync(SearchTerm, OnlyActive)).AsQueryable();
+
             if (SelectedCategoryId.HasValue)
                 articles = articles.Where(a => a.CategoryId == SelectedCategoryId);
-            
-            if (OnlyActive)
-                articles = articles.Where(a => a.NewsStatus == true);
-            
+
             Articles = articles.OrderByDescending(a => a.CreatedDate).ToList();
         }
     }

--- a/DangQuangTien_RazorPages/Pages/Report/Index.cshtml.cs
+++ b/DangQuangTien_RazorPages/Pages/Report/Index.cshtml.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using DAL.Entities;
-using DAL.Repositories;
+using ServiceLayer.Interfaces;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -12,11 +12,11 @@ namespace DangQuangTien_RazorPages.Pages.Report
 {
     public class IndexModel : PageModel
     {
-        private readonly INewsArticleRepository _newsRepo;
+        private readonly INewsService _news;
 
-        public IndexModel(INewsArticleRepository newsRepo)
+        public IndexModel(INewsService news)
         {
-            _newsRepo = newsRepo;
+            _news = news;
         }
 
         [BindProperty(SupportsGet = true)]
@@ -33,7 +33,7 @@ namespace DangQuangTien_RazorPages.Pages.Report
             if (role == null || role != 0)
                 return RedirectToPage("/Account/Login");
 
-            var allNews = await _newsRepo.GetAllAsync(null);
+            var allNews = await _news.GetAllAsync();
 
             NewsStats = allNews
                 .Where(n =>


### PR DESCRIPTION
## Summary
- refactor News and Report index pages to use `INewsService` and `ICategoryService`
- remove direct repository usage for better layering

## Testing
- `dotnet build DangQuangTien_Se171443_A02.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867d39ec6d8832da19e49dcf0f64a6e