### PR TITLE
Fix popup forms for CRUD operations

### DIFF
--- a/DangQuangTien_RazorPages/Pages/Account/Create.cshtml
+++ b/DangQuangTien_RazorPages/Pages/Account/Create.cshtml
@@ -4,33 +4,8 @@
 
 <h2>New Account</h2>
 
-<form method="post">
-    <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
-    <div class="mb-3">
-        <label asp-for="Account.AccountName" class="form-label"></label>
-        <input asp-for="Account.AccountName" class="form-control" />
-        <span asp-validation-for="Account.AccountName" class="text-danger"></span>
-    </div>
-    <div class="mb-3">
-        <label asp-for="Account.AccountEmail" class="form-label"></label>
-        <input asp-for="Account.AccountEmail" class="form-control" />
-        <span asp-validation-for="Account.AccountEmail" class="text-danger"></span>
-    </div>
-    <div class="mb-3">
-        <label asp-for="Account.AccountPassword" class="form-label"></label>
-        <input asp-for="Account.AccountPassword" type="password" class="form-control" />
-        <span asp-validation-for="Account.AccountPassword" class="text-danger"></span>
-    </div>
-    <div class="mb-3">
-        <label asp-for="Account.AccountRole" class="form-label"></label>
-        <select asp-for="Account.AccountRole" class="form-select">
-            <option value="1">Staff</option>
-            <option value="2">Lecturer</option>
-        </select>
-    </div>
-    <button type="submit" class="btn btn-success">Create</button>
-    <a asp-page="Index" class="btn btn-secondary">Cancel</a>
-</form>
+@await Html.PartialAsync("_CreateFormPartial", Model)
+<a asp-page="Index" class="btn btn-secondary mt-2">Cancel</a>
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />

--- a/DangQuangTien_RazorPages/Pages/Account/Create.cshtml.cs
+++ b/DangQuangTien_RazorPages/Pages/Account/Create.cshtml.cs
@@ -23,6 +23,14 @@ namespace DangQuangTien_RazorPages.Pages.Account
             return Page();
         }
 
+        public IActionResult OnGetForm()
+        {
+            var result = OnGet();
+            if (result is PageResult)
+                return Partial("_CreateFormPartial", this);
+            return result;
+        }
+
         public async Task<IActionResult> OnPostAsync()
         {
             var role = HttpContext.Session.GetInt32("AccountRole");

--- a/DangQuangTien_RazorPages/Pages/Account/Delete.cshtml
+++ b/DangQuangTien_RazorPages/Pages/Account/Delete.cshtml
@@ -4,15 +4,5 @@
 
 <h2>Delete Account</h2>
 
-<h4>Are you sure you want to delete this account?</h4>
-<div class="mb-3">
-    <strong>Email:</strong> @Model.Account?.AccountEmail
-</div>
-<div class="mb-3">
-    <strong>Role:</strong> @(Model.Account?.AccountRole == 1 ? "Staff" : "Lecturer")
-</div>
-<form method="post" data-confirm="Are you sure you want to delete this account?">
-    <input type="hidden" asp-for="Account!.AccountId" />
-    <button type="submit" class="btn btn-danger">Delete</button>
-    <a asp-page="Index" class="btn btn-secondary">Cancel</a>
-</form>
+@await Html.PartialAsync("_DeleteFormPartial", Model)
+<a asp-page="Index" class="btn btn-secondary mt-2">Cancel</a>

--- a/DangQuangTien_RazorPages/Pages/Account/Delete.cshtml.cs
+++ b/DangQuangTien_RazorPages/Pages/Account/Delete.cshtml.cs
@@ -28,6 +28,14 @@ namespace DangQuangTien_RazorPages.Pages.Account
             return Page();
         }
 
+        public async Task<IActionResult> OnGetFormAsync(short id)
+        {
+            var result = await OnGetAsync(id);
+            if (result is PageResult)
+                return Partial("_DeleteFormPartial", this);
+            return result;
+        }
+
         public async Task<IActionResult> OnPostAsync()
         {
             var role = HttpContext.Session.GetInt32("AccountRole");

--- a/DangQuangTien_RazorPages/Pages/Account/Edit.cshtml
+++ b/DangQuangTien_RazorPages/Pages/Account/Edit.cshtml
@@ -4,39 +4,8 @@
 
 <h2>Edit Account</h2>
 
-<form method="post" asp-antiforgery="true" data-confirm="Save changes to this account?">
-    <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
-    <input type="hidden" asp-for="Account.AccountId" />
-
-    <div class="mb-3">
-        <label asp-for="Account.AccountName" class="form-label"></label>
-        <input asp-for="Account.AccountName" class="form-control" />
-        <span asp-validation-for="Account.AccountName" class="text-danger"></span>
-    </div>
-
-    <div class="mb-3">
-        <label asp-for="Account.AccountEmail" class="form-label"></label>
-        <input asp-for="Account.AccountEmail" class="form-control" />
-        <span asp-validation-for="Account.AccountEmail" class="text-danger"></span>
-    </div>
-
-    <div class="mb-3">
-        <label asp-for="Account.AccountPassword" class="form-label"></label>
-        <input asp-for="Account.AccountPassword" type="password" class="form-control" />
-        <span asp-validation-for="Account.AccountPassword" class="text-danger"></span>
-    </div>
-
-    <div class="mb-3">
-        <label asp-for="Account.AccountRole" class="form-label"></label>
-        <select asp-for="Account.AccountRole" class="form-select">
-            <option value="1">Staff</option>
-            <option value="2">Lecturer</option>
-        </select>
-    </div>
-
-    <button type="submit" class="btn btn-primary">Save</button>
-    <a asp-page="Index" class="btn btn-secondary">Cancel</a>
-</form>
+@await Html.PartialAsync("_EditFormPartial", Model)
+<a asp-page="Index" class="btn btn-secondary mt-2">Cancel</a>
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />

--- a/DangQuangTien_RazorPages/Pages/Account/Edit.cshtml.cs
+++ b/DangQuangTien_RazorPages/Pages/Account/Edit.cshtml.cs
@@ -29,6 +29,14 @@ namespace DangQuangTien_RazorPages.Pages.Account
             return Page();
         }
 
+        public async Task<IActionResult> OnGetFormAsync(short id)
+        {
+            var result = await OnGetAsync(id);
+            if (result is PageResult)
+                return Partial("_EditFormPartial", this);
+            return result;
+        }
+
         public async Task<IActionResult> OnPostAsync()
         {
             var role = HttpContext.Session.GetInt32("AccountRole");

--- a/DangQuangTien_RazorPages/Pages/Account/_CreateFormPartial.cshtml
+++ b/DangQuangTien_RazorPages/Pages/Account/_CreateFormPartial.cshtml
@@ -1,0 +1,27 @@
+@model DangQuangTien_RazorPages.Pages.Account.CreateModel
+<form method="post" asp-page="Create">
+    <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
+    <div class="mb-3">
+        <label asp-for="Account.AccountName" class="form-label"></label>
+        <input asp-for="Account.AccountName" class="form-control" />
+        <span asp-validation-for="Account.AccountName" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Account.AccountEmail" class="form-label"></label>
+        <input asp-for="Account.AccountEmail" class="form-control" />
+        <span asp-validation-for="Account.AccountEmail" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Account.AccountPassword" class="form-label"></label>
+        <input asp-for="Account.AccountPassword" type="password" class="form-control" />
+        <span asp-validation-for="Account.AccountPassword" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Account.AccountRole" class="form-label"></label>
+        <select asp-for="Account.AccountRole" class="form-select">
+            <option value="1">Staff</option>
+            <option value="2">Lecturer</option>
+        </select>
+    </div>
+    <button type="submit" class="btn btn-success">Create</button>
+</form>

--- a/DangQuangTien_RazorPages/Pages/Account/_DeleteFormPartial.cshtml
+++ b/DangQuangTien_RazorPages/Pages/Account/_DeleteFormPartial.cshtml
@@ -1,0 +1,11 @@
+@model DangQuangTien_RazorPages.Pages.Account.DeleteModel
+<h4>Are you sure you want to delete this account?</h4>
+<div class="mb-3">
+    <strong>Email:</strong> @Model.Account?.AccountEmail
+</div>
+<div class="mb-3">
+    <strong>Role:</strong> @(Model.Account?.AccountRole == 1 ? "Staff" : "Lecturer")
+</div>
+<form method="post" asp-page="Delete" asp-route-id="@Model.Account!.AccountId" data-confirm="Are you sure you want to delete this account?">
+    <button type="submit" class="btn btn-danger">Delete</button>
+</form>

--- a/DangQuangTien_RazorPages/Pages/Account/_EditFormPartial.cshtml
+++ b/DangQuangTien_RazorPages/Pages/Account/_EditFormPartial.cshtml
@@ -1,0 +1,28 @@
+@model DangQuangTien_RazorPages.Pages.Account.EditModel
+<form method="post" asp-page="Edit" asp-route-id="@Model.Account.AccountId" data-confirm="Save changes to this account?">
+    <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
+    <input type="hidden" asp-for="Account.AccountId" />
+    <div class="mb-3">
+        <label asp-for="Account.AccountName" class="form-label"></label>
+        <input asp-for="Account.AccountName" class="form-control" />
+        <span asp-validation-for="Account.AccountName" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Account.AccountEmail" class="form-label"></label>
+        <input asp-for="Account.AccountEmail" class="form-control" />
+        <span asp-validation-for="Account.AccountEmail" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Account.AccountPassword" class="form-label"></label>
+        <input asp-for="Account.AccountPassword" type="password" class="form-control" />
+        <span asp-validation-for="Account.AccountPassword" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Account.AccountRole" class="form-label"></label>
+        <select asp-for="Account.AccountRole" class="form-select">
+            <option value="1">Staff</option>
+            <option value="2">Lecturer</option>
+        </select>
+    </div>
+    <button type="submit" class="btn btn-primary">Save</button>
+</form>

--- a/DangQuangTien_RazorPages/Pages/Category/Create.cshtml
+++ b/DangQuangTien_RazorPages/Pages/Category/Create.cshtml
@@ -4,33 +4,8 @@
 
 <h2>New Category</h2>
 
-<form method="post">
-    <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
-
-    <div class="mb-3">
-        <label asp-for="Category.CategoryName" class="form-label"></label>
-        <input asp-for="Category.CategoryName" class="form-control" />
-        <span asp-validation-for="Category.CategoryName" class="text-danger"></span>
-    </div>
-
-    <div class="mb-3">
-        <label asp-for="Category.CategoryDesciption" class="form-label"></label>
-        <textarea asp-for="Category.CategoryDesciption" class="form-control"></textarea>
-        <span asp-validation-for="Category.CategoryDesciption" class="text-danger"></span>
-    </div>
-    <div class="mb-3">
-        <label asp-for="Category.IsActive" class="form-label"></label>
-        <input asp-for="Category.IsActive"
-               class="form-control"
-               style="width: 100px; display: inline-block;"
-               placeholder="true/false" />
-        <span asp-validation-for="Category.IsActive" class="text-danger"></span>
-    </div>
-
-
-    <button type="submit" class="btn btn-success">Create</button>
-    <a asp-page="Index" class="btn btn-secondary">Cancel</a>
-</form>
+@await Html.PartialAsync("_CreateFormPartial", Model)
+<a asp-page="Index" class="btn btn-secondary mt-2">Cancel</a>
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />

--- a/DangQuangTien_RazorPages/Pages/Category/Create.cshtml.cs
+++ b/DangQuangTien_RazorPages/Pages/Category/Create.cshtml.cs
@@ -20,6 +20,12 @@ namespace DangQuangTien_RazorPages.Pages.Category
 
         public void OnGet() { }
 
+        public IActionResult OnGetForm()
+        {
+            OnGet();
+            return Partial("_CreateFormPartial", this);
+        }
+
         public async Task<IActionResult> OnPostAsync()
         {
             if (!ModelState.IsValid)

--- a/DangQuangTien_RazorPages/Pages/Category/Delete.cshtml
+++ b/DangQuangTien_RazorPages/Pages/Category/Delete.cshtml
@@ -4,27 +4,5 @@
 
 <h2>Delete Category</h2>
 
-<div class="mb-3">
-    <p>Are you sure you want to delete:</p>
-    <dl class="row">
-        <dt class="col-sm-2">Name</dt>
-        <dd class="col-sm-10">@Model.Category?.CategoryName</dd>
-        <dt class="col-sm-2">Description</dt>
-        <dd class="col-sm-10">@Model.Category?.CategoryDesciption</dd>
-    </dl>
-</div>
-
-<form method="post" data-confirm="Are you sure you want to delete this category?">
-    <button type="submit" class="btn btn-danger">Delete</button>
-    <a asp-page="Index" class="btn btn-secondary">Cancel</a>
-</form>
-
-@if (!ViewData.ModelState.IsValid)
-{
-    <div class="text-danger mt-3">
-        @foreach (var err in ViewData.ModelState[string.Empty].Errors)
-        {
-            <p>@err.ErrorMessage</p>
-        }
-    </div>
-}
+@await Html.PartialAsync("_DeleteFormPartial", Model)
+<a asp-page="Index" class="btn btn-secondary mt-2">Cancel</a>

--- a/DangQuangTien_RazorPages/Pages/Category/Delete.cshtml.cs
+++ b/DangQuangTien_RazorPages/Pages/Category/Delete.cshtml.cs
@@ -14,11 +14,19 @@ namespace DangQuangTien_RazorPages.Pages.Category
         [BindProperty]
         public CategoryEntity? Category { get; set; }
 
-        public async Task<IActionResult> OnGetAsync(short id)  
+        public async Task<IActionResult> OnGetAsync(short id)
         {
             Category = await _svc.GetByIdAsync(id);
             if (Category == null) return RedirectToPage("Index");
             return Page();
+        }
+
+        public async Task<IActionResult> OnGetFormAsync(short id)
+        {
+            var result = await OnGetAsync(id);
+            if (result is PageResult)
+                return Partial("_DeleteFormPartial", this);
+            return result;
         }
 
         public async Task<IActionResult> OnPostAsync(short id) 

--- a/DangQuangTien_RazorPages/Pages/Category/Edit.cshtml
+++ b/DangQuangTien_RazorPages/Pages/Category/Edit.cshtml
@@ -4,36 +4,8 @@
 
 <h2>Edit Category</h2>
 
-<form method="post" data-confirm="Save changes to this category?">
-    <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
-
-    <input type="hidden" asp-for="Category.CategoryId" />
-
-    <div class="mb-3">
-        <label asp-for="Category.CategoryName" class="form-label"></label>
-        <input asp-for="Category.CategoryName" class="form-control" />
-        <span asp-validation-for="Category.CategoryName" class="text-danger"></span>
-    </div>
-
-    <div class="mb-3">
-        <label asp-for="Category.CategoryDesciption" class="form-label"></label>
-        <textarea asp-for="Category.CategoryDesciption" class="form-control"></textarea>
-        <span asp-validation-for="Category.CategoryDesciption" class="text-danger"></span>
-    </div>
-
-    <div class="mb-3">
-        <label asp-for="Category.IsActive" class="form-label"></label>
-        <input asp-for="Category.IsActive"
-               class="form-control"
-               style="width: 100px; display: inline-block;"
-               placeholder="true/false" />
-        <span asp-validation-for="Category.IsActive" class="text-danger"></span>
-    </div>
-
-
-    <button type="submit" class="btn btn-warning">Save</button>
-    <a asp-page="Index" class="btn btn-secondary">Cancel</a>
-</form>
+@await Html.PartialAsync("_EditFormPartial", Model)
+<a asp-page="Index" class="btn btn-secondary mt-2">Cancel</a>
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />

--- a/DangQuangTien_RazorPages/Pages/Category/Edit.cshtml.cs
+++ b/DangQuangTien_RazorPages/Pages/Category/Edit.cshtml.cs
@@ -14,11 +14,19 @@ namespace DangQuangTien_RazorPages.Pages.Category
         [BindProperty]
         public CategoryEntity Category { get; set; } = null!;
 
-        public async Task<IActionResult> OnGetAsync(short id) 
+        public async Task<IActionResult> OnGetAsync(short id)
         {
             Category = await _svc.GetByIdAsync(id);
             if (Category == null) return RedirectToPage("Index");
             return Page();
+        }
+
+        public async Task<IActionResult> OnGetFormAsync(short id)
+        {
+            var result = await OnGetAsync(id);
+            if (result is PageResult)
+                return Partial("_EditFormPartial", this);
+            return result;
         }
 
         public async Task<IActionResult> OnPostAsync()

--- a/DangQuangTien_RazorPages/Pages/Category/_CreateFormPartial.cshtml
+++ b/DangQuangTien_RazorPages/Pages/Category/_CreateFormPartial.cshtml
@@ -1,0 +1,20 @@
+@model DangQuangTien_RazorPages.Pages.Category.CreateModel
+<form method="post" asp-page="Create">
+    <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
+    <div class="mb-3">
+        <label asp-for="Category.CategoryName" class="form-label"></label>
+        <input asp-for="Category.CategoryName" class="form-control" />
+        <span asp-validation-for="Category.CategoryName" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Category.CategoryDesciption" class="form-label"></label>
+        <textarea asp-for="Category.CategoryDesciption" class="form-control"></textarea>
+        <span asp-validation-for="Category.CategoryDesciption" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Category.IsActive" class="form-label"></label>
+        <input asp-for="Category.IsActive" class="form-control" style="width: 100px; display: inline-block;" placeholder="true/false" />
+        <span asp-validation-for="Category.IsActive" class="text-danger"></span>
+    </div>
+    <button type="submit" class="btn btn-success">Create</button>
+</form>

--- a/DangQuangTien_RazorPages/Pages/Category/_DeleteFormPartial.cshtml
+++ b/DangQuangTien_RazorPages/Pages/Category/_DeleteFormPartial.cshtml
@@ -1,0 +1,22 @@
+@model DangQuangTien_RazorPages.Pages.Category.DeleteModel
+<div class="mb-3">
+    <p>Are you sure you want to delete:</p>
+    <dl class="row">
+        <dt class="col-sm-2">Name</dt>
+        <dd class="col-sm-10">@Model.Category?.CategoryName</dd>
+        <dt class="col-sm-2">Description</dt>
+        <dd class="col-sm-10">@Model.Category?.CategoryDesciption</dd>
+    </dl>
+</div>
+<form method="post" asp-page="Delete" asp-route-id="@Model.Category?.CategoryId" data-confirm="Are you sure you want to delete this category?">
+    <button type="submit" class="btn btn-danger">Delete</button>
+</form>
+@if (!ViewData.ModelState.IsValid)
+{
+    <div class="text-danger mt-3">
+        @foreach (var err in ViewData.ModelState[string.Empty].Errors)
+        {
+            <p>@err.ErrorMessage</p>
+        }
+    </div>
+}

--- a/DangQuangTien_RazorPages/Pages/Category/_EditFormPartial.cshtml
+++ b/DangQuangTien_RazorPages/Pages/Category/_EditFormPartial.cshtml
@@ -1,0 +1,21 @@
+@model DangQuangTien_RazorPages.Pages.Category.EditModel
+<form method="post" asp-page="Edit" asp-route-id="@Model.Category.CategoryId" data-confirm="Save changes to this category?">
+    <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
+    <input type="hidden" asp-for="Category.CategoryId" />
+    <div class="mb-3">
+        <label asp-for="Category.CategoryName" class="form-label"></label>
+        <input asp-for="Category.CategoryName" class="form-control" />
+        <span asp-validation-for="Category.CategoryName" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Category.CategoryDesciption" class="form-label"></label>
+        <textarea asp-for="Category.CategoryDesciption" class="form-control"></textarea>
+        <span asp-validation-for="Category.CategoryDesciption" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Category.IsActive" class="form-label"></label>
+        <input asp-for="Category.IsActive" class="form-control" style="width: 100px; display: inline-block;" placeholder="true/false" />
+        <span asp-validation-for="Category.IsActive" class="text-danger"></span>
+    </div>
+    <button type="submit" class="btn btn-warning">Save</button>
+</form>

--- a/DangQuangTien_RazorPages/Pages/News/_CreateFormPartial.cshtml
+++ b/DangQuangTien_RazorPages/Pages/News/_CreateFormPartial.cshtml
@@ -1,5 +1,5 @@
 @model DangQuangTien_RazorPages.Pages.News.CreateModel
-<form method="post">
+<form method="post" asp-page="Create">
     <div class="mb-3">
         <label asp-for="Article.NewsTitle" class="form-label"></label>
         <input asp-for="Article.NewsTitle" class="form-control" />

--- a/DangQuangTien_RazorPages/Pages/News/_DeleteFormPartial.cshtml
+++ b/DangQuangTien_RazorPages/Pages/News/_DeleteFormPartial.cshtml
@@ -10,7 +10,7 @@
     <dt class="col-sm-3">Created</dt>
     <dd class="col-sm-9">@Model.Article?.CreatedDate?.ToLocalTime().ToString("g")</dd>
 </dl>
-<form method="post" data-confirm="Are you sure you want to delete this article?">
+<form method="post" asp-page="Delete" asp-route-id="@Model.Article.NewsArticleId" data-confirm="Are you sure you want to delete this article?">
     <input type="hidden" asp-for="Article.NewsArticleId" />
     <button type="submit" class="btn btn-danger">Delete</button>
 </form>

--- a/DangQuangTien_RazorPages/Pages/News/_EditFormPartial.cshtml
+++ b/DangQuangTien_RazorPages/Pages/News/_EditFormPartial.cshtml
@@ -1,5 +1,5 @@
 @model DangQuangTien_RazorPages.Pages.News.EditModel
-<form method="post" data-confirm="Save changes to this article?">
+<form method="post" asp-page="Edit" asp-route-id="@Model.Article.NewsArticleId" data-confirm="Save changes to this article?">
     <input type="hidden" asp-for="Article.NewsArticleId" />
     <div class="mb-3">
         <label asp-for="Article.NewsTitle" class="form-label"></label>


### PR DESCRIPTION
## Summary
- support modal-based create/edit/delete for Account and Category pages using new partial forms
- ensure News modal forms post to correct handlers
- add handler methods to serve partials for all CRUD pages

## Testing
- `dotnet build DangQuangTien_Se171443_A02.sln -c Release` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686880aebfd4832dad9e34389ea14940