### PR TITLE
Fix missing edit/delete buttons after SignalR update

### DIFF
--- a/DangQuangTien_RazorPages/Pages/News/Index.cshtml.cs
+++ b/DangQuangTien_RazorPages/Pages/News/Index.cshtml.cs
@@ -71,6 +71,11 @@ namespace DangQuangTien_RazorPages.Pages.News
             if (role != 1)
             {
                 this.OnlyActive = true;
+                CanEdit = false;
+            }
+            else
+            {
+                CanEdit = true;
             }
 
             await LoadArticles();


### PR DESCRIPTION
## Summary
- keep `CanEdit` flag when refreshing News table via SignalR partial

## Testing
- `dotnet build DangQuangTien_Se171443_A02.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686886bac2b4832dbafdfa7b0293a65c