### PR TITLE
Fix duplicate deletion confirmation

### DIFF
--- a/DangQuangTien_RazorPages/Pages/Account/_DeleteFormPartial.cshtml
+++ b/DangQuangTien_RazorPages/Pages/Account/_DeleteFormPartial.cshtml
@@ -6,6 +6,6 @@
 <div class="mb-3">
     <strong>Role:</strong> @(Model.Account?.AccountRole == 1 ? "Staff" : "Lecturer")
 </div>
-<form method="post" asp-page="Delete" asp-route-id="@Model.Account!.AccountId" data-confirm="Are you sure you want to delete this account?">
+<form method="post" asp-page="Delete" asp-route-id="@Model.Account!.AccountId">
     <button type="submit" class="btn btn-danger">Delete</button>
 </form>

--- a/DangQuangTien_RazorPages/Pages/Category/_DeleteFormPartial.cshtml
+++ b/DangQuangTien_RazorPages/Pages/Category/_DeleteFormPartial.cshtml
@@ -8,7 +8,7 @@
         <dd class="col-sm-10">@Model.Category?.CategoryDesciption</dd>
     </dl>
 </div>
-<form method="post" asp-page="Delete" asp-route-id="@Model.Category?.CategoryId" data-confirm="Are you sure you want to delete this category?">
+<form method="post" asp-page="Delete" asp-route-id="@Model.Category?.CategoryId">
     <button type="submit" class="btn btn-danger">Delete</button>
 </form>
 @if (!ViewData.ModelState.IsValid)

--- a/DangQuangTien_RazorPages/Pages/News/_DeleteFormPartial.cshtml
+++ b/DangQuangTien_RazorPages/Pages/News/_DeleteFormPartial.cshtml
@@ -10,7 +10,7 @@
     <dt class="col-sm-3">Created</dt>
     <dd class="col-sm-9">@Model.Article?.CreatedDate?.ToLocalTime().ToString("g")</dd>
 </dl>
-<form method="post" asp-page="Delete" asp-route-id="@Model.Article.NewsArticleId" data-confirm="Are you sure you want to delete this article?">
+<form method="post" asp-page="Delete" asp-route-id="@Model.Article.NewsArticleId">
     <input type="hidden" asp-for="Article.NewsArticleId" />
     <button type="submit" class="btn btn-danger">Delete</button>
 </form>


### PR DESCRIPTION
## Summary
- remove `data-confirm` from delete partial forms so only custom modal is used

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868887a6b08832dbf299f13a57363b8