### PR TITLE
Fix new account creation

### DIFF
--- a/DAL/Contexts/AppDbContext.cs
+++ b/DAL/Contexts/AppDbContext.cs
@@ -102,7 +102,7 @@ public partial class AppDbContext : DbContext
             entity.HasKey(e => e.AccountId);
 
             entity.Property(e => e.AccountId)
-                .ValueGeneratedNever()
+                .ValueGeneratedOnAdd()
                 .HasColumnName("AccountID");
             entity.Property(e => e.AccountEmail).HasMaxLength(70);
             entity.Property(e => e.AccountName).HasMaxLength(100);


### PR DESCRIPTION
## Summary
- configure `SystemAccount` ID as auto-increment so new accounts aren't inserted with ID=0

## Testing
- `dotnet build DangQuangTien_Se171443_A02.sln`

------
https://chatgpt.com/codex/tasks/task_e_686890f54450832d8f7690889096aad5