### PR TITLE
Fix SystemAccount insertion error

### DIFF
--- a/DAL/Contexts/AppDbContext.cs
+++ b/DAL/Contexts/AppDbContext.cs
@@ -101,8 +101,9 @@ public partial class AppDbContext : DbContext
         {
             entity.HasKey(e => e.AccountId);
 
+            // ID is generated manually in the repository
             entity.Property(e => e.AccountId)
-                .ValueGeneratedOnAdd()
+                .ValueGeneratedNever()
                 .HasColumnName("AccountID");
             entity.Property(e => e.AccountEmail).HasMaxLength(70);
             entity.Property(e => e.AccountName).HasMaxLength(100);

--- a/DAL/Repositories/SystemAccountRepository.cs
+++ b/DAL/Repositories/SystemAccountRepository.cs
@@ -46,6 +46,17 @@ namespace DAL.Repositories
 
         public async Task AddAsync(SystemAccount account)
         {
+            // Assign a new unique ID when the database does not auto generate it
+            if (account.AccountId == 0)
+            {
+                short nextId = 1;
+                if (_ctx.SystemAccount.Any())
+                {
+                    nextId = (short)(_ctx.SystemAccount.Max(a => a.AccountId) + 1);
+                }
+                account.AccountId = nextId;
+            }
+
             await _ctx.SystemAccount.AddAsync(account);
             await _ctx.SaveChangesAsync();
         }


### PR DESCRIPTION
## Summary
- manage SystemAccount IDs inside repository rather than rely on DB auto increment
- update EF Core mapping so AccountId isn't treated as DB generated

## Testing
- `dotnet build DangQuangTien_Se171443_A02.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686892601184832d84aa03c038fbafe2