### PR TITLE
Improve popup design and default login page

### DIFF
--- a/DangQuangTien_RazorPages/Pages/Index.cshtml.cs
+++ b/DangQuangTien_RazorPages/Pages/Index.cshtml.cs
@@ -12,9 +12,15 @@ namespace DangQuangTien_RazorPages.Pages
             _logger = logger;
         }
 
-        public void OnGet()
+        public IActionResult OnGet()
         {
+            var email = HttpContext.Session.GetString("AccountEmail");
+            if (string.IsNullOrEmpty(email))
+            {
+                return RedirectToPage("/Account/Login");
+            }
 
+            return Page();
         }
     }
 }

--- a/DangQuangTien_RazorPages/Pages/Shared/_CreatePopupPartial.cshtml
+++ b/DangQuangTien_RazorPages/Pages/Shared/_CreatePopupPartial.cshtml
@@ -1,7 +1,13 @@
 <div class="modal fade" id="createModal" tabindex="-1" aria-labelledby="createModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-lg">
         <div class="modal-content">
-            <!-- Create form is loaded here -->
+            <div class="modal-header">
+                <h5 class="modal-title" id="createModalLabel">Add New</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <!-- Create form is loaded here -->
+            </div>
         </div>
     </div>
 </div>

--- a/DangQuangTien_RazorPages/Pages/Shared/_DeletePopupPartial.cshtml
+++ b/DangQuangTien_RazorPages/Pages/Shared/_DeletePopupPartial.cshtml
@@ -1,7 +1,13 @@
 <div class="modal fade" id="deleteModal" tabindex="-1" aria-labelledby="deleteModalLabel" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
-            <!-- Delete form is loaded here -->
+            <div class="modal-header">
+                <h5 class="modal-title" id="deleteModalLabel">Confirm Delete</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <!-- Delete form is loaded here -->
+            </div>
         </div>
     </div>
 </div>

--- a/DangQuangTien_RazorPages/Pages/Shared/_EditPopupPartial.cshtml
+++ b/DangQuangTien_RazorPages/Pages/Shared/_EditPopupPartial.cshtml
@@ -1,7 +1,13 @@
 <div class="modal fade" id="editModal" tabindex="-1" aria-labelledby="editModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-lg">
         <div class="modal-content">
-            <!-- Edit form is loaded here -->
+            <div class="modal-header">
+                <h5 class="modal-title" id="editModalLabel">Edit Item</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <!-- Edit form is loaded here -->
+            </div>
         </div>
     </div>
 </div>

--- a/DangQuangTien_RazorPages/Pages/Shared/_Layout.cshtml
+++ b/DangQuangTien_RazorPages/Pages/Shared/_Layout.cshtml
@@ -33,7 +33,6 @@
                         <li class="nav-item"><a class="nav-link text-dark" asp-page="/News/Index">View News</a></li>
                         @if (role == 1)
                         {
-                            <li class="nav-item"><a class="nav-link text-success fw-bold" asp-page="/News/Create" data-popup="create">+ New Article</a></li>
                             <li class="nav-item"><a class="nav-link text-primary" asp-page="/News/NewsHistory">My News</a></li>
                             <li class="nav-item"><a class="nav-link text-info" asp-page="/Account/Profile">My Profile</a></li>
                         }

--- a/DangQuangTien_RazorPages/wwwroot/js/createPopup.js
+++ b/DangQuangTien_RazorPages/wwwroot/js/createPopup.js
@@ -11,7 +11,7 @@ document.addEventListener('click', function (e) {
         .then(function (r) { return r.text(); })
         .then(function (html) {
             const modalEl = document.getElementById('createModal');
-            modalEl.querySelector('.modal-content').innerHTML = html;
+            modalEl.querySelector('.modal-body').innerHTML = html;
             const modal = new bootstrap.Modal(modalEl);
             modal.show();
         });

--- a/DangQuangTien_RazorPages/wwwroot/js/deletePopup.js
+++ b/DangQuangTien_RazorPages/wwwroot/js/deletePopup.js
@@ -11,7 +11,7 @@ document.addEventListener('click', function (e) {
         .then(function (r) { return r.text(); })
         .then(function (html) {
             const modalEl = document.getElementById('deleteModal');
-            modalEl.querySelector('.modal-content').innerHTML = html;
+            modalEl.querySelector('.modal-body').innerHTML = html;
             const modal = new bootstrap.Modal(modalEl);
             modal.show();
         });

--- a/DangQuangTien_RazorPages/wwwroot/js/editPopup.js
+++ b/DangQuangTien_RazorPages/wwwroot/js/editPopup.js
@@ -11,7 +11,7 @@ document.addEventListener('click', function (e) {
         .then(function (r) { return r.text(); })
         .then(function (html) {
             const modalEl = document.getElementById('editModal');
-            modalEl.querySelector('.modal-content').innerHTML = html;
+            modalEl.querySelector('.modal-body').innerHTML = html;
             const modal = new bootstrap.Modal(modalEl);
             modal.show();
         });


### PR DESCRIPTION
## Summary
- redirect unauthenticated users from the home page to the login page
- style create/edit/delete modal popups with headers and close buttons
- load AJAX form contents into modal bodies
- remove `+ New Article` from the navigation bar

## Testing
- `dotnet build DangQuangTien_Se171443_A02.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868b181b0bc832dbe944ad828f6bc72