### PR TITLE
Fix admin account deletion with modal popup

### DIFF
--- a/DangQuangTien_RazorPages/Pages/Account/Delete.cshtml.cs
+++ b/DangQuangTien_RazorPages/Pages/Account/Delete.cshtml.cs
@@ -36,14 +36,13 @@ namespace DangQuangTien_RazorPages.Pages.Account
             return result;
         }
 
-        public async Task<IActionResult> OnPostAsync()
+        public async Task<IActionResult> OnPostAsync(short id)
         {
             var role = HttpContext.Session.GetInt32("AccountRole");
             if (role != 0)
                 return RedirectToPage("/Account/AccessDenied");
 
-            if (Account != null)
-                await _svc.DeleteAsync(Account.AccountId);
+            await _svc.DeleteAsync(id);
 
             return RedirectToPage("Index");
         }

--- a/DangQuangTien_RazorPages/Pages/Account/Index.cshtml
+++ b/DangQuangTien_RazorPages/Pages/Account/Index.cshtml
@@ -40,7 +40,7 @@
                     @if (acc.AccountId != 0)
                     {
                         <a asp-page="Edit" asp-route-id="@acc.AccountId" class="btn btn-sm btn-warning me-1" data-popup="edit">Edit</a>
-                        <a asp-page="Delete" asp-route-id="@acc.AccountId" class="btn btn-sm btn-danger" data-confirm="Are you sure you want to delete this account?">Delete</a>
+                        <a asp-page="Delete" asp-route-id="@acc.AccountId" class="btn btn-sm btn-danger" data-popup="delete">Delete</a>
                     }
                 </td>
             </tr>


### PR DESCRIPTION
## Summary
- fix Delete account page to accept account id and remove unused property
- enable delete modal popup on account management

## Testing
- `dotnet build DangQuangTien_RazorPages/DangQuangTien_RazorPages.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6868c2530754832d9ad4d2b8171e7e37