### PR TITLE
Fix missing admin action buttons after account creation

### DIFF
--- a/DangQuangTien_RazorPages/Pages/Account/Index.cshtml
+++ b/DangQuangTien_RazorPages/Pages/Account/Index.cshtml
@@ -37,11 +37,8 @@
 
                 </td>
                 <td>
-                    @if (acc.AccountId != 0)
-                    {
-                        <a asp-page="Edit" asp-route-id="@acc.AccountId" class="btn btn-sm btn-warning me-1" data-popup="edit">Edit</a>
-                        <a asp-page="Delete" asp-route-id="@acc.AccountId" class="btn btn-sm btn-danger" data-popup="delete">Delete</a>
-                    }
+                    <a asp-page="Edit" asp-route-id="@acc.AccountId" class="btn btn-sm btn-warning me-1" data-popup="edit">Edit</a>
+                    <a asp-page="Delete" asp-route-id="@acc.AccountId" class="btn btn-sm btn-danger" data-popup="delete">Delete</a>
                 </td>
             </tr>
         }


### PR DESCRIPTION
## Summary
- always render Edit/Delete buttons in the admin account list

## Testing
- `dotnet build DangQuangTien_Se171443_A02.sln -clp:Summary`

------
https://chatgpt.com/codex/tasks/task_e_6868ca553df0832dac2b6d035e38bb91